### PR TITLE
Fixed an issue where button's setTitle(string:state:) did not respond  to a title change.

### DIFF
--- a/Sources/PMSuperButton.swift
+++ b/Sources/PMSuperButton.swift
@@ -54,7 +54,7 @@ open class PMSuperButton: UIButton {
     }
     @IBInspectable open var letterSpacing: CGFloat = 0 {
         didSet {
-            self.setAttributedTitle(getAttributedString(with: self.titleLabel?.text, letterSpacing: letterSpacing), for: self.state)
+            super.setAttributedTitle(addAttribute(with: self.titleLabel?.text, letterSpacing: letterSpacing), for: self.state)
         }
     }
     
@@ -97,8 +97,16 @@ open class PMSuperButton: UIButton {
     // MARK: Overrides
     
     override open func setTitle(_ title: String?, for state: UIControlState) {
-        // setTitle always sets attributed text
-        self.setAttributedTitle(getAttributedString(with: title, letterSpacing: letterSpacing), for: state)
+        super.setAttributedTitle(addAttribute(with: title, letterSpacing: letterSpacing), for: state)
+    }
+    
+    override open func setAttributedTitle(_ title: NSAttributedString?, for state: UIControlState) {
+        let attr = getAttributedString(string: title?.string)
+        super.setAttributedTitle(attr, for: state)
+    }
+    
+    override open func setTitleColor(_ color: UIColor?, for state: UIControlState) {
+        super.setAttributedTitle(addAttribute(titleColor: color), for:state)
     }
     
     //MARK: - Animations
@@ -245,19 +253,37 @@ open class PMSuperButton: UIButton {
     
     // MARK: Private methods
     
-    // Get the NSMutableAttributedString with kern value: optional("string") ?? "";
-    // Button's previous attributedText is kept, only mutableString value is changed.
-    private func getAttributedString(with string:String?, letterSpacing spacing:CGFloat) -> NSMutableAttributedString {
+    // Add letter spacing attribute
+    private func addAttribute(with string:String?, letterSpacing spacing:CGFloat) -> NSMutableAttributedString {
+        let attr = getAttributedString(string: string)
+        attr.addAttribute(NSAttributedStringKey.kern, value: spacing, range: NSRange(location: 0, length: attr.length))
+        return attr
+    }
+    
+    // Add title color attribute
+    private func addAttribute(titleColor:UIColor?) -> NSMutableAttributedString {
+        let attr = getAttributedString()
+        if let color = titleColor {
+            attr.addAttribute(NSAttributedStringKey.foregroundColor, value: color, range: NSRange(location: 0, length: attr.length))
+        }
+        return attr
+    }
+    
+    // Get titleLabel current attribute string
+    private func getAttributedString(string:String? = nil) -> NSMutableAttributedString {
         var attr:NSMutableAttributedString!
-        if let string = string, let attrText = self.titleLabel?.attributedText {
-            let attrString = NSMutableAttributedString(attributedString:attrText)
-            attrString.mutableString.setString(string)
-            attr = attrString
+        if let attrText = self.titleLabel?.attributedText {
+            attr = NSMutableAttributedString(attributedString:attrText)
         } else {
-            attr = NSMutableAttributedString(string:string ?? "")
+            attr = NSMutableAttributedString(string:"")
         }
         
-        attr.addAttribute(NSAttributedStringKey.kern, value: spacing, range: NSRange(location: 0, length: attr.length))
+        if let string = string {
+            attr.mutableString.setString(string)
+        } else if let string = self.titleLabel?.text {
+            attr.mutableString.setString(string)
+        }
+        
         return attr
     }
 }

--- a/Sources/PMSuperButton.swift
+++ b/Sources/PMSuperButton.swift
@@ -54,9 +54,7 @@ open class PMSuperButton: UIButton {
     }
     @IBInspectable open var letterSpacing: CGFloat = 0 {
         didSet {
-            let attributes = getAttributedString()
-            attributes.addAttribute(NSAttributedStringKey.kern, value: letterSpacing, range: NSRange(location: 0, length: attributes.length))
-            self.setAttributedTitle(attributes, for: .normal)
+            self.setAttributedTitle(getAttributedString(with: self.titleLabel?.text, letterSpacing: letterSpacing), for: self.state)
         }
     }
     
@@ -94,6 +92,13 @@ open class PMSuperButton: UIButton {
             gradient!.endPoint = CGPoint(x: 0, y: 1)
         }
         self.layer.insertSublayer(gradient!, below: self.imageView?.layer)
+    }
+    
+    // MARK: Overrides
+    
+    override open func setTitle(_ title: String?, for state: UIControlState) {
+        // setTitle always sets attributed text
+        self.setAttributedTitle(getAttributedString(with: title, letterSpacing: letterSpacing), for: state)
     }
     
     //MARK: - Animations
@@ -240,15 +245,20 @@ open class PMSuperButton: UIButton {
     
     // MARK: Private methods
     
-    // Return button's label attributed string based on optional attributedText or text
-    private func getAttributedString() -> NSMutableAttributedString {
-        if let attr = self.titleLabel?.attributedText {
-            return NSMutableAttributedString(attributedString: attr)
+    // Get the NSMutableAttributedString with kern value: optional("string") ?? "";
+    // Button's previous attributedText is kept, only mutableString value is changed.
+    private func getAttributedString(with string:String?, letterSpacing spacing:CGFloat) -> NSMutableAttributedString {
+        var attr:NSMutableAttributedString!
+        if let string = string, let attrText = self.titleLabel?.attributedText {
+            let attrString = NSMutableAttributedString(attributedString:attrText)
+            attrString.mutableString.setString(string)
+            attr = attrString
+        } else {
+            attr = NSMutableAttributedString(string:string ?? "")
         }
-        if let text = self.titleLabel?.text {
-            return NSMutableAttributedString(string: text)
-        }
-        return NSMutableAttributedString()
+        
+        attr.addAttribute(NSAttributedStringKey.kern, value: spacing, range: NSRange(location: 0, length: attr.length))
+        return attr
     }
 }
 


### PR DESCRIPTION
Hi, @Codeido 
Thanks for accepting my PR.

We have a problem in previous PR's implementation 😶:
Everythings works OK if the developer configures the button only through the storyboard.
But, if there is a need to change the title of the button programmatically, then a problem arises:

```swift
button.setTitle("Button title", for: .normal) // Won't change the title
```

> The cause of the problem was the getAttributedString() method, which always returned the value .attributedText and ignored the value of .text;

I fixed the issue.
Now we have a flexible function:
```swift
// Get the NSMutableAttributedString with kern value: optional("string") ?? "";
// Button's previous attributedText is kept, only mutableString value is changed.
private func getAttributedString(with string:String?, letterSpacing spacing:CGFloat) -> NSMutableAttributedString {
    var attr:NSMutableAttributedString!
    if let string = string, let attrText = self.titleLabel?.attributedText {
        let attrString = NSMutableAttributedString(attributedString:attrText)
        attrString.mutableString.setString(string)
        attr = attrString
    } else {
        attr = NSMutableAttributedString(string:string ?? "")
    }
    
    attr.addAttribute(NSAttributedStringKey.kern, value: spacing, range: NSRange(location: 0, length: attr.length))
    return attr
}
```

In the **future** PR with another **attributed string** features, we may create another common private function which will return `titleLabel's` **NSMutableAttributedString** with a single **string** parameter.

Thanks!