### PR TITLE
- fixed disabling gradient

### DIFF
--- a/Sources/PMSuperButton.swift
+++ b/Sources/PMSuperButton.swift
@@ -75,11 +75,12 @@ open class PMSuperButton: UIButton {
     var gradient: CAGradientLayer?
     
     func setupGradient(){
+        gradient?.removeFromSuperlayer()
+        
         guard gradientEnabled != false else{
             return
         }
         
-        gradient?.removeFromSuperlayer()
         gradient = CAGradientLayer()
         guard let gradient = gradient else { return }
         


### PR DESCRIPTION
It wasn't possible to disable gradient by `.gradientEnabled = false` if it was already enabled.